### PR TITLE
Load kernel into memory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![no_main]
 #![feature(abi_efiapi)]
+use core::clone;
+use core::fmt::Write;
 use uefi::prelude::*;
 use uefi::proto::media::file::{File, FileAttribute, FileMode};
 use uefi::CStr16;
@@ -9,24 +11,38 @@ use uefi::CStr16;
 fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
     uefi_services::init(&mut system_table).unwrap();
 
-    let fs = system_table
-        .boot_services()
-        .get_image_file_system(handle)
-        .unwrap();
+    writeln!(system_table.stdout(), "hello from bootloader").unwrap();
+
     unsafe {
+        let fs_sytem_table = system_table.unsafe_clone();
+        let fs = fs_sytem_table
+            .boot_services()
+            .get_image_file_system(handle)
+            .unwrap();
         let mut volume = (*fs.interface.get()).open_volume().unwrap();
 
         let mut kernel_filename_buffer = [0; 7];
         let kernel_filename =
             CStr16::from_str_with_buf("kernel", &mut kernel_filename_buffer).unwrap();
 
-        let handle = volume
-            .open(kernel_filename, FileMode::Read, FileAttribute::READ_ONLY)
-            .unwrap();
+        let handle_result = volume.open(kernel_filename, FileMode::Read, FileAttribute::READ_ONLY);
+        let handle = match handle_result {
+            Ok(handle) => handle,
+            Err(error) if error.status() == uefi::Status::NOT_FOUND => {
+                writeln!(system_table.stdout(), "file not found.").unwrap();
+                panic!("dame");
+            }
+            Err(_) => {
+                writeln!(system_table.stdout(), "other error.").unwrap();
+                panic!("dame");
+            }
+        };
         let mut file = handle.into_regular_file().unwrap();
         // TODO: allocate enough memory
         let mut buffer = [0; 10000];
-        let _nbytes = file.read(&mut buffer).unwrap();
+        let nbytes = file.read(&mut buffer).unwrap();
+
+        writeln!(system_table.stdout(), "{}", nbytes).unwrap();
 
         // TODO: Move the instruction pointer to the address stored at (buffer + 24).
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,9 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
     unsafe {
         let mut volume = (*fs.interface.get()).open_volume().unwrap();
 
-        let mut buf = [0; 7];
-        let kernel_filename = CStr16::from_str_with_buf("kernel", &mut buf).unwrap();
+        let mut kernel_filename_buffer = [0; 7];
+        let kernel_filename =
+            CStr16::from_str_with_buf("kernel", &mut kernel_filename_buffer).unwrap();
 
         let handle = volume
             .open(kernel_filename, FileMode::Read, FileAttribute::READ_ONLY)

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
     unsafe {
         let mut volume = (*fs.interface.get()).open_volume().unwrap();
 
-        let mut buf = [0; 4];
+        let mut buf = [0; 7];
         let kernel_filename = CStr16::from_str_with_buf("kernel", &mut buf).unwrap();
 
         let handle = volume


### PR DESCRIPTION
Load "kernel" to the memory as a preparation for booting.

Upcoming changes:
- Allocate memory dynamically instead of heap
- Jump to the loaded instructions